### PR TITLE
Fixed a typo in the path

### DIFF
--- a/src/main/scala/tutorial/Tutorial6.scala
+++ b/src/main/scala/tutorial/Tutorial6.scala
@@ -24,7 +24,7 @@ To run this job:
   yarn jar target/scalding-tutorial-0.11.2.jar Tutorial6 --local 
 
 Check the output:
-  cat tutorial/data/output6.tsv
+  cat target/data/output6.tsv
 
 **/
 


### PR DESCRIPTION
Fixed a typo in the path of the embedded instructions.
